### PR TITLE
Fixed typos in settings.xamlstyler

### DIFF
--- a/settings.xamlstyler
+++ b/settings.xamlstyler
@@ -1,9 +1,9 @@
 {
     "AttributesTolerance": 1,
     "KeepFirstAttributeOnSameLine": true,
-    "MaxAttributeCharatersPerLine": 0,
+    "MaxAttributeCharactersPerLine": 0,
     "MaxAttributesPerLine": 1,
-    "NewlineExemptionElements": "RadialGradientBrush, GradientStop, LinearGradientBrush, ScaleTransfom, SkewTransform, RotateTransform, TranslateTransform, Trigger, Condition, Setter",
+    "NewlineExemptionElements": "RadialGradientBrush, GradientStop, LinearGradientBrush, ScaleTransform, SkewTransform, RotateTransform, TranslateTransform, Trigger, Condition, Setter",
     "SeparateByGroups": false,
     "AttributeIndentation": 0,
     "AttributeIndentationStyle": 1,


### PR DESCRIPTION
I was comparing your settings.xamlstyler with mine to see the difference and noticed a few typos (I've been using this file for about a month and copied the settings from here https://github.com/Xavalon/XamlStyler/wiki/External-Configurations).
I originally noticed this issue in
WindowsCommunityToolkit and thought it might be a CopyPaste issue